### PR TITLE
Config.py: replace default server IP with localhost 

### DIFF
--- a/Config.py
+++ b/Config.py
@@ -1,4 +1,4 @@
-ServerIP="10.0.0.2"
+ServerIP="localhost"
 ServerPort=5555
 
 PlayerSpeed=3


### PR DESCRIPTION
replace default server IP with localhost so that it works out of the box on any local server